### PR TITLE
Venv fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ sudo wget -qcO /usr/local/bin/macro https://raw.githubusercontent.com/brokenpylo
 
 ## Commands
 
-| Command                        | Description                                                            |
-| -----------------------------  | ---------------------------------------------------------------------- |
-|```macro record```              | Record the macro (exit with ```C-d```)                                 |
-|```macro```                     | Replay the recorded macro                                              |
-|```macro view```                | Print the recorded commands to the terminal                            |
-|```macro edit```                | Edit the commands using ```$EDITOR```                                  |
-|```macro save <file>```         | Save the macro to a file named ```<file>```                            |
-|```source <(macro keep)```      | Keep the history of the current session when recording                 |
-|```macro help```                | Print the usage                                                        |
-|```REGISTER=<register> macro``` | Use the register ```<register>``` (default one is called ```default```)|
+| Command                               | Description                                                            |
+| ------------------------------------- | ---------------------------------------------------------------------- |
+|```macro record```                     | Record the macro (exit with ```C-d```)                                 |
+|```macro``` or ```source macro```      | Replay the recorded macro in new or current environment                |
+|```macro view```                       | Print the recorded commands to the terminal                            |
+|```macro edit```                       | Edit the commands using ```$EDITOR```                                  |
+|```macro save <file>```                | Save the macro to a file named ```<file>```                            |
+|```source <(macro keep)```             | Keep the history of the current session when recording                 |
+|```macro help```                       | Print the usage                                                        |
+|```REGISTER=<register> source macro``` | Use the register ```<register>``` (default one is called ```default```)|
 
 Each command can be called by using just the first letter (e.g. ```macro r``` instead of ```macro record```).
 
@@ -39,14 +39,18 @@ The script stores the registers and the history in the ```~/.local/share/macro``
 
 The intended way to use multiple registers is to create an alias for each of them. You can do that by calling:
 ```
+# Run macro in new bash env, then switch back to current bash env
 alias <name>='REGISTER=<register> macro '
+
+# Run macro in current bash env
+alias <name>='REGISTER=<register> source macro '
 ```
 
 For example, you can use the following configuration:
 ```
 for x in {a..z}
 do
-    eval "alias q$x='REGISTER=$x macro '"
+    eval "alias q$x='REGISTER=$x source macro '"
 done
 ```
 This adds commands of the form ```q<register>``` (e.g. ```qq``` for register q). For recording you call ```qq r``` and then replay the macro using ```qq```.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install by cloning the repository and running:
 
 ```
 sudo cp macro /usr/local/bin
+
+# Or
+
+sudo wget -qcO /usr/local/bin/macro https://raw.githubusercontent.com/brokenpylons/macro/master/macro
 ```
 
 ## Commands

--- a/macro
+++ b/macro
@@ -7,7 +7,7 @@ read -r -d '' rc << EOF
 source ~/.bashrc
 PS1="(recording)\$PS1"
 [[ \$KEEPHISTORY == 1 ]] && HISTFILE="$historyfile" history -r
-HISTFILE="$registerfile" 
+HISTFILE="$registerfile"
 EOF
 
 read -r -d '' keephistory << EOF


### PR DESCRIPTION
Hi, thank you for great project, wish it has more stars.

I tried to activate python's venv with macro, but it didn't work. 

Turns out that `macro` should be called with `source` to run in same bash environment, so I add this info into `README.md`. 

Also I add new way to install `macro` with `wget`.